### PR TITLE
Changing deprecated locked attribute to status

### DIFF
--- a/contrib/odoo/addons_v9/controllers/outbound.py
+++ b/contrib/odoo/addons_v9/controllers/outbound.py
@@ -907,8 +907,8 @@ class exporter(object):
                 if not location or not operation in self.operations:
                     continue
                 qty = self.convert_qty_uom(i['product_qty'], i['product_uom'][0], i['product_id'][0])
-                yield '<operationplan operation=%s start="%s" end="%s" quantity="%s" locked="true"/>\n' % (
-                    quoteattr(operation), startdate, startdate, qty
+                yield '<operationplan operation=%s start="%s" end="%s" quantity="%s" status="%s"/>\n' % (
+                    quoteattr(operation), startdate, startdate, qty, i['state']
                 )
         yield '</operationplans>\n'
 


### PR DESCRIPTION
Because locked has been deprecated and it is no longer found in the XSD